### PR TITLE
Add custom calendar footer

### DIFF
--- a/Diary/Diary/Controls/CalendarFooter.xaml
+++ b/Diary/Diary/Controls/CalendarFooter.xaml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentView
+    x:Class="Diary.Controls.CalendarFooter"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:Diary.Converters"
+    xmlns:fonts="clr-namespace:Diary.Resources.Fonts"
+    xmlns:plugin="clr-namespace:Plugin.Maui.Calendar.Controls;assembly=Plugin.Maui.Calendar"
+    x:DataType="plugin:Calendar">
+    <ContentView.Resources>
+        <ResourceDictionary>
+            <converters:DateStringToCalendarFooterText x:Key="DateStringToCalendarFooterText" />
+        </ResourceDictionary>
+    </ContentView.Resources>
+
+    <Grid
+        ColumnDefinitions="Auto,*"
+        HeightRequest="40"
+        HorizontalOptions="Fill"
+        RowSpacing="6"
+        VerticalOptions="Fill">
+        <Label
+            Grid.Column="0"
+            FontAttributes="Bold"
+            FontSize="Medium"
+            Text="{Binding SelectedDateText, Converter={StaticResource DateStringToCalendarFooterText}}"
+            TextColor="{Binding SelectedDateColor}"
+            VerticalOptions="Center"
+            VerticalTextAlignment="Center" />
+
+        <Label
+            x:Name="showHideLabel"
+            Grid.Column="1"
+            Margin="0,0,15,0"
+            BackgroundColor="Transparent"
+            FontAttributes="Bold"
+            FontFamily="{Static fonts:Fonts.FontAwesome}"
+            FontSize="20"
+            HorizontalOptions="End"
+            IsVisible="{Binding FooterArrowVisible}"
+            Text="{Static fonts:FontAwesomeIcons.ArrowUp}"
+            TextColor="{Binding SelectedDateColor}"
+            VerticalOptions="Center"
+            VerticalTextAlignment="Center">
+            <Label.Triggers>
+                <DataTrigger
+                    Binding="{Binding CalendarSectionShown}"
+                    TargetType="Label"
+                    Value="False">
+                    <Setter Property="Text" Value="{Static fonts:FontAwesomeIcons.ArrowDown}" />
+                </DataTrigger>
+            </Label.Triggers>
+        </Label>
+        <Grid.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding ShowHideCalendarCommand}" />
+        </Grid.GestureRecognizers>
+    </Grid>
+</ContentView>

--- a/Diary/Diary/Controls/CalendarFooter.xaml.cs
+++ b/Diary/Diary/Controls/CalendarFooter.xaml.cs
@@ -1,0 +1,9 @@
+namespace Diary.Controls;
+
+public partial class CalendarFooter : ContentView
+{
+	public CalendarFooter()
+	{
+		InitializeComponent();
+	}
+}

--- a/Diary/Diary/Converters/DateStringToCalendarFooterText.cs
+++ b/Diary/Diary/Converters/DateStringToCalendarFooterText.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+
+namespace Diary.Converters;
+
+public class DateStringToCalendarFooterText : IValueConverter
+{
+    public static readonly string DefaultText = "All entries";
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string dateString)
+        {
+            return string.IsNullOrEmpty(dateString) ? DefaultText : dateString;
+        }
+
+        return DefaultText;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string dateString)
+        {
+            return dateString == DefaultText ? string.Empty : dateString;
+        }
+        return string.Empty;
+    }
+}

--- a/Diary/Diary/Diary.csproj
+++ b/Diary/Diary/Diary.csproj
@@ -135,6 +135,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="Controls\CalendarFooter.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Resources\Dictionaries\BaseResourceDictionary.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/Diary/Diary/Views/Entry/EntryListView.xaml
+++ b/Diary/Diary/Views/Entry/EntryListView.xaml
@@ -3,6 +3,7 @@
     x:Class="Diary.Views.Entry.EntryListView"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Diary.Controls"
     xmlns:fonts="clr-namespace:Diary.Resources.Fonts"
     xmlns:models="clr-namespace:Diary.Models.Entry"
     xmlns:plugin="clr-namespace:Plugin.Maui.Calendar.Controls;assembly=Plugin.Maui.Calendar"
@@ -48,7 +49,13 @@
             TodayTextColor="{AppThemeBinding Light={StaticResource PrimaryDarkText},
                                              Dark={StaticResource PrimaryLightText}}"
             VerticalOptions="Fill"
-            YearLabelColor="{StaticResource Primary}" />
+            YearLabelColor="{StaticResource Primary}">
+            <plugin:Calendar.FooterSectionTemplate>
+                <DataTemplate>
+                    <controls:CalendarFooter />
+                </DataTemplate>
+            </plugin:Calendar.FooterSectionTemplate>
+        </plugin:Calendar>
 
         <ScrollView Grid.Row="1">
             <StackLayout BindableLayout.ItemsSource="{Binding SelectedDayEntries}" Orientation="Vertical">


### PR DESCRIPTION
PR přidává custom calendar footer, který zobrazuje text, i když v kalendáři není vybrán žádný den. V dosavadním řešení se žádný text nezobrazoval. Calendar má nějaké properties, přes které by to mělo jít nastavit, ale z nějakého důvodu se ten text po přepínání dnů vždycky vymazal.

![00](https://github.com/therazix/pv239-diary/assets/55061728/0e5ac3fd-9dd0-4690-97b0-104922c9871b)

@yoshi29 Podobně jsem chtěl vyřešit i to, aby byl kalendář při prvním spuštění aplikace zabalen, ale nepodařilo se mi přijít na způsob, který by fungoval. Pokud bys náhodou věděla, jak to udělat, tak by to bylo super, ale jinak tím asi nemá cenu ztrácet čas.