### PR TITLE
Select correct day from different month in calendar

### DIFF
--- a/Diary/Diary/ViewModels/Entry/EntryListViewModel.cs
+++ b/Diary/Diary/ViewModels/Entry/EntryListViewModel.cs
@@ -47,7 +47,7 @@ public partial class EntryListViewModel : ViewModelBase
 
         Events = ConstructEventCollection(Items);
 
-        DaySelected(DateTime.Now.Date);
+        DaySelected();
     }
 
     private EventCollection ConstructEventCollection(ICollection<EntryListModel> items)
@@ -63,7 +63,7 @@ public partial class EntryListViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void DaySelected(DateTime dateTime)
+    private void DaySelected()
     {
         // When deselecting the date, show all entries
         if (SelectedDate == null)
@@ -72,6 +72,7 @@ public partial class EntryListViewModel : ViewModelBase
         }
         else
         {
+            var dateTime = DateTime.Parse(SelectedDate);
             var dayHasEvents = Events.TryGetValue(dateTime.Date, out var dayEvents);
 
             if (dayHasEvents)


### PR DESCRIPTION
Při testování seedů k #26 jsem narazil jsem na bug při přepínání dnů v kalendáři. Zkus si stáhnout tu větev, která přidává nové seedy, smaž předešlá data aplikace, aby se to znovu naseedovalo a spusť aplikaci.
Když se ti po spuštění aplikace zobrazí kalendář, klikni na 1. 6. a normálně se ti zobrazí záznam z daného dne. Potom hned klikni na předešlý den (31. 5.), který je z minulého měsíce a z nějakého důvodu to do `DaySelected` commandu pošle špatné datum (3. 5.), ale `SelectedDate` property ho má nastavený správně (31. 5.).

Upravil jsem teda ten command, aby to bral jen podle `SelectedDate` stringu a vypadá to, že to funguje správně.